### PR TITLE
Documentation, FAQ.md, generated_headers

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -432,7 +432,7 @@ sources in the build target:
 libfoo_gen_headers = custom_target('gen-headers', ..., output: 'foo-gen.h')
 libfoo_sources = files('foo-utils.c', 'foo-lib.c')
 # Add generated headers to the list of sources for the build target
-libfoo = library('foo', sources: libfoo_sources + libfoo_gen_headers)
+libfoo = library('foo', sources: libfoo_sources + libfoo_gen_headers.to_list())
 ```
 
 Now let's say you have a new target that links to `libfoo`:


### PR DESCRIPTION
Fixed code fragment in the "How do I tell Meson that my sources use generated headers?" section in the FAQ.
Now this fragment will work without throwing an error.
Fixes issue  [#7317](https://github.com/mesonbuild/meson/issues/7317).